### PR TITLE
fix: macos app name

### DIFF
--- a/src/macos/main_app.py
+++ b/src/macos/main_app.py
@@ -44,7 +44,7 @@ class TriageDashboard(ttk.Frame):
         notes_frame.pack(padx=10, pady=10, fill="both", expand=True)
         self.notes_text = scrolledtext.ScrolledText(notes_frame, wrap=tk.WORD, height=5)
         self.notes_text.pack(padx=5, pady=5, fill="both", expand=True)
-        self.notes_text.insert(tk.END, "Enter any relevant details about the issue here...")
+        self.notes_text.insert(tk.END, "Enter job name, date and any relevant details about the issue here...")
 
         button_frame = ttk.Frame(self)
         button_frame.pack(pady=5)


### PR DESCRIPTION
y resolve that to the more familiar macOS marketing name (like Sonoma, Ventura, etc.).
This is a macOS-specific feature. Placed this logic in the src/macos/network_toolkit.py file. It overrides the basic get_system_info method from the shared toolkit and adds the name resolution just for the macOS version.

